### PR TITLE
RSDK-13341: Document get_images source names

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ The following attributes are available for the Gemini 335Le model:
 | `640X480` | `640X480` |
 
 
+## `get_images` Source Names
+
+`get_images` supports two source names for use with `filter_source_names`:
+
+| Source Name | MIME Type | Description |
+|-------------|-----------|-------------|
+| `color` | `image/jpeg` (MJPG) or `image/png` (RGB) | Color image from the RGB sensor |
+| `depth` | `image/vnd.viam.dep` | Depth map from the depth sensor |
+
+Both color and depth streams are always enabled in the pipeline. The `sensors` attribute configures resolution and format but does not disable either stream.
+
+If `filter_source_names` is empty, both `color` and `depth` images are returned. If populated, only the matching source names are returned. Unrecognized names are ignored.
+
 ## Attributes
 A call to get_attributes will return the camera attributes in [this struct](https://github.com/viamrobotics/viam-cpp-sdk/blob/43deea420f572e6b61b6fbd519e09b2520f05676/src/viam/sdk/components/camera.hpp#L58)
 


### PR DESCRIPTION
## Summary
- Documents the two `filter_source_names` values (`color` and `depth`) that `get_images` can return
- Documents MIME types for each source and behavior when filter is empty vs populated
- Clarifies that both streams are always enabled and the `sensors` attribute only configures resolution/format

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)